### PR TITLE
Add Bootstrap overview page highlighting system capabilities

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -8,6 +8,11 @@ from core import admin_dashboard  # noqa: F401  # Importa para aplicar o dashboa
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="home.html"), name="home"),
+    path(
+        "sobre-o-sistema/",
+        TemplateView.as_view(template_name="system_overview.html"),
+        name="system_overview",
+    ),
     path('admin/', admin.site.urls),
     path('accounts/', include('accounts.urls', namespace='accounts')),
 ]

--- a/templates/system_overview.html
+++ b/templates/system_overview.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sobre o Sistema | Colmeia Online</title>
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+        crossorigin="anonymous"
+    >
+</head>
+<body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
+        <div class="container">
+            <a class="navbar-brand fw-semibold" href="/">Colmeia Online</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                aria-controls="navbarNav" aria-expanded="false" aria-label="Alternar navegação">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="#recursos">Recursos</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#criadores">Criadores por região</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="btn btn-outline-light ms-lg-3" href="{% url 'admin:index' %}">Acessar painel admin</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <header class="py-5 bg-white border-bottom">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-lg-7">
+                    <h1 class="display-5 fw-bold text-primary mb-3">Organize seus meliponários com eficiência</h1>
+                    <p class="lead text-muted">
+                        O Colmeia Online é um sistema completo para acompanhar a saúde das colmeias, registrar revisões
+                        e conectar criadores por todo o país. Conheça os principais recursos e descubra como a plataforma pode
+                        apoiar o crescimento responsável da meliponicultura.
+                    </p>
+                    <a class="btn btn-primary btn-lg mt-2" href="{% url 'accounts:login' %}">Entrar no sistema</a>
+                </div>
+                <div class="col-lg-5 mt-4 mt-lg-0">
+                    <div class="card border-0 shadow-sm">
+                        <div class="card-body">
+                            <h2 class="h5 fw-semibold">Principais destaques</h2>
+                            <ul class="list-unstyled mb-0">
+                                <li class="d-flex align-items-start mt-3">
+                                    <span class="badge bg-primary-subtle text-primary-emphasis me-3">1</span>
+                                    <div>
+                                        <h3 class="h6 mb-1">Gestão de meliponários</h3>
+                                        <p class="text-muted mb-0">Cadastre locais de criação, registre espécies e acompanhe a evolução das colmeias.</p>
+                                    </div>
+                                </li>
+                                <li class="d-flex align-items-start mt-3">
+                                    <span class="badge bg-primary-subtle text-primary-emphasis me-3">2</span>
+                                    <div>
+                                        <h3 class="h6 mb-1">Revisões inteligentes</h3>
+                                        <p class="text-muted mb-0">Planeje inspeções periódicas, anexe observações e monitore colmeias sem revisão.</p>
+                                    </div>
+                                </li>
+                                <li class="d-flex align-items-start mt-3">
+                                    <span class="badge bg-primary-subtle text-primary-emphasis me-3">3</span>
+                                    <div>
+                                        <h3 class="h6 mb-1">Colaboração entre criadores</h3>
+                                        <p class="text-muted mb-0">Compartilhe experiências, troque contatos e encontre parceiros na mesma região.</p>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main class="py-5">
+        <div class="container">
+            <section id="recursos" class="mb-5">
+                <h2 class="h3 fw-semibold text-primary mb-4">O que você pode fazer na plataforma</h2>
+                <div class="row g-4">
+                    <div class="col-md-4">
+                        <div class="card h-100 shadow-sm border-0">
+                            <div class="card-body">
+                                <h3 class="h5">Mapear colmeias</h3>
+                                <p class="text-muted">
+                                    Acompanhe cada colmeia registrada, com informações detalhadas, status de revisão e alertas
+                                    sobre necessidades de manutenção.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100 shadow-sm border-0">
+                            <div class="card-body">
+                                <h3 class="h5">Monitorar revisões</h3>
+                                <p class="text-muted">
+                                    Registre as inspeções realizadas, organize as tarefas futuras e receba lembretes das colmeias
+                                    que estão há mais tempo sem cuidado.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100 shadow-sm border-0">
+                            <div class="card-body">
+                                <h3 class="h5">Catalogar espécies</h3>
+                                <p class="text-muted">
+                                    Monte seu catálogo particular de espécies criadas, acompanhe produtividade e crie relatórios
+                                    personalizados para cada meliponário.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section id="criadores">
+                <div class="d-flex flex-column flex-md-row align-items-md-center mb-3">
+                    <h2 class="h3 fw-semibold text-primary mb-0">Criadores por região</h2>
+                    <p class="text-muted ms-md-3 mb-0">Tabela demonstrativa que será expandida com dados reais em breve.</p>
+                </div>
+                <div class="table-responsive shadow-sm">
+                    <table class="table table-hover table-striped mb-0">
+                        <thead class="table-primary">
+                            <tr>
+                                <th scope="col">Nome</th>
+                                <th scope="col">Telefone</th>
+                                <th scope="col">Região</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Maria Silva</td>
+                                <td>(11) 91234-5678</td>
+                                <td>Sudeste</td>
+                            </tr>
+                            <tr>
+                                <td>João Pereira</td>
+                                <td>(71) 99876-5432</td>
+                                <td>Nordeste</td>
+                            </tr>
+                            <tr>
+                                <td>Ana Souza</td>
+                                <td>(51) 93456-7890</td>
+                                <td>Sul</td>
+                            </tr>
+                            <tr>
+                                <td>Carlos Lima</td>
+                                <td>(62) 98765-4321</td>
+                                <td>Centro-Oeste</td>
+                            </tr>
+                            <tr>
+                                <td>Fernanda Rocha</td>
+                                <td>(92) 95678-1234</td>
+                                <td>Norte</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="py-4 bg-white border-top">
+        <div class="container text-center">
+            <p class="text-muted mb-1">&copy; {% now "Y" %} Colmeia Online. Todos os direitos reservados.</p>
+            <small class="text-muted">Conectando criadores de abelhas sem ferrão em todo o Brasil.</small>
+        </div>
+    </footer>
+
+    <script
+        src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+        crossorigin="anonymous"
+    ></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new public route that serves a system overview template
- create a Bootstrap-based overview page describing platform features and showing a sample creators table with admin access link

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db046afd188332b5678df54b93b405