### PR TITLE
Fix admin dashboard species scientific name display and mobile menu

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -22,6 +22,7 @@ class RevisionEntry:
     hive_name: str
     hive_url: str
     species_name: str
+    species_scientific_name: str | None
     apiary_name: str | None
     apiary_url: str | None
     review_date_display: str
@@ -64,8 +65,7 @@ def _build_recent_revisions(user) -> List[RevisionEntry]:
                 hive_name=str(hive),
                 hive_url=reverse("admin:apiary_hive_change", args=[hive.pk]),
                 species_name=hive.species.popular_name,
-                # TODO: Dando erro aqui: unexpected keyword argument 'species_scientific_name'
-                species_scientific_name=hive.species.scientific_name,
+                species_scientific_name=hive.species.scientific_name or None,
                 apiary_name=apiary.name if apiary else None,
                 apiary_url=reverse("admin:apiary_apiary_change", args=[apiary.pk]) if apiary else None,
                 review_date_display=formatted_datetime,

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,86 @@
+{% extends "admin/base.html" %}
+{% load i18n %}
+
+{% block title %}{% if title %}{{ title }} | {% endif %}{{ site_title|default:_("Django site admin") }}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_("Django administration") }}</a></h1>
+{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+        .mobile-menu {
+            display: none;
+        }
+
+        @media (max-width: 450px) {
+            .mobile-menu {
+                display: block;
+                position: fixed;
+                left: 10px;
+                bottom: 10px;
+                z-index: 99;
+                padding: 4px 10px;
+                border: none;
+                border-radius: 5px;
+                background: #febe35;
+                color: #ffffff;
+                font-size: 15px;
+                font-weight: 600;
+                box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+                cursor: pointer;
+            }
+
+            .mobile-menu:focus-visible,
+            .mobile-menu:hover {
+                background: #f6a509;
+            }
+        }
+    </style>
+{% endblock %}
+
+{% block footer %}
+    {{ block.super }}
+    <button type="button" class="mobile-menu" aria-controls="nav-sidebar" aria-expanded="true">
+        Menu
+    </button>
+    <script>
+        (function () {
+            const button = document.querySelector('.mobile-menu');
+            const sidebar = document.getElementById('nav-sidebar');
+
+            if (!button || !sidebar) {
+                if (button) {
+                    button.remove();
+                }
+                return;
+            }
+
+            const toggleSidebar = () => {
+                const isVisible = sidebar.style.display !== 'none' && window.getComputedStyle(sidebar).display !== 'none';
+                if (isVisible) {
+                    sidebar.style.display = 'none';
+                    button.setAttribute('aria-expanded', 'false');
+                } else {
+                    sidebar.style.display = 'block';
+                    button.setAttribute('aria-expanded', 'true');
+                }
+            };
+
+            button.addEventListener('click', toggleSidebar);
+
+            const handleResize = () => {
+                if (window.innerWidth > 450) {
+                    sidebar.style.display = '';
+                    button.setAttribute('aria-expanded', 'true');
+                }
+            };
+
+            window.addEventListener('resize', handleResize);
+            handleResize();
+        })();
+    </script>
+{% endblock %}

--- a/templates/admin/custom_dashboard.html
+++ b/templates/admin/custom_dashboard.html
@@ -186,6 +186,10 @@
         color: var(--dashboard-muted);
     }
 
+    .dashboard-item__scientific {
+        font-style: italic;
+    }
+
     .dashboard-item__actions {
         display: flex;
         flex-wrap: wrap;
@@ -325,42 +329,6 @@
 {% endblock %}
 
 {% block content %}
-
-<!-- TODO: Preciso que isso fique disponivel em todas as telas do admin, nao apenas no dashboard -->
-<style>
-    .mobile-menu {
-        display: none;
-    }
-
-    @media (max-width: 450px) {
-        .mobile-menu {
-            display: block;
-            background: #febe35;
-            border: unset;
-            border-radius: 5px;
-            padding: 4px 8px;
-            position: fixed;
-            z-index: 99;
-            left: 10px;
-            bottom: 10px;
-            color: white;
-            font-size: 15px;
-        }
-    }
-</style>
-<button class="mobile-menu">Menu</button>
-<script>
-    // ao clicar no mobile menu, alternar a visibilidade da sidebar #nav-sidebar
-    document.querySelector('.mobile-menu').addEventListener('click', function() {
-        const sidebar = document.getElementById('nav-sidebar');
-        if (sidebar.style.display === 'block') {
-            sidebar.style.display = 'none';
-        } else {
-            sidebar.style.display = 'block';
-        }
-    });
-</script>
-
 <div class="colmeia-dashboard" role="main">
     <div class="colmeia-dashboard__main">
         <div class="dashboard-cards" role="list" aria-label="Resumo geral">
@@ -393,7 +361,12 @@
                             <li class="dashboard-list__item">
                                 <a class="dashboard-item__primary" href="{{ revision.change_url }}">
                                     <span class="dashboard-item__title"><time datetime="{{ revision.review_time_iso }}">{{ revision.review_date_display }}</time></span>
-                                    <span class="dashboard-item__subtitle">{{ revision.hive_name }} · {{ revision.species_name }}{% if revision.scientific_name %}{% endif %}</span>
+                                    <span class="dashboard-item__subtitle">
+                                        {{ revision.hive_name }} · {{ revision.species_name }}
+                                        {% if revision.species_scientific_name %}
+                                            <span class="dashboard-item__scientific">({{ revision.species_scientific_name }})</span>
+                                        {% endif %}
+                                    </span>
                                 </a>
                                 <div class="dashboard-item__actions">
                                     <a class="dashboard-action-link" href="{{ revision.hive_url }}">Ver colmeia</a>


### PR DESCRIPTION
## Summary
- include the species scientific name in the recent revisions dashboard context and template
- move the mobile menu toggle into the shared admin base template so it appears across all admin pages

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc49e80a90833295128316a20d6d1d