### PR TITLE
Fix hive validation for missing owner when linking apiary

### DIFF
--- a/apiary/models.py
+++ b/apiary/models.py
@@ -225,10 +225,14 @@ class Hive(models.Model):
 
     def clean(self) -> None:
         super().clean()
-        if self.apiary and self.owner and self.apiary.owner_id != self.owner_id:
-            raise ValidationError(
-                {"apiary": "A colmeia só pode ser vinculada a meliponários/apiários do mesmo usuário."}
-            )
+        if self.apiary_id and self.owner_id:
+            apiary_owner_id = self.apiary.owner_id if self.apiary else None
+            if apiary_owner_id != self.owner_id:
+                raise ValidationError(
+                    {
+                        "apiary": "A colmeia só pode ser vinculada a meliponários/apiários do mesmo usuário."
+                    }
+                )
 
     def save(self, *args, **kwargs):
         previous_apiary_id = None


### PR DESCRIPTION
## Summary
- avoid accessing the owner relation inside `Hive.clean` before it exists so validation works when creating hives

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dd2795272083329634540f3231e16f