### PR TITLE
Enable Select2 globally in Django admin

### DIFF
--- a/apiary/admin.py
+++ b/apiary/admin.py
@@ -3,7 +3,20 @@ from django.contrib import admin
 from .models import Apiary, Hive, Revision, RevisionAttachment, Species
 
 
-class OwnerRestrictedAdmin(admin.ModelAdmin):
+class Select2AdminMixin:
+    class Media:
+        css = {
+            "all": (
+                "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css",
+            )
+        }
+        js = (
+            "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.full.min.js",
+            "apiary/js/hive_species_filter.js",
+        )
+
+
+class OwnerRestrictedAdmin(Select2AdminMixin, admin.ModelAdmin):
     owner_field_name = "owner"
 
     def get_queryset(self, request):
@@ -54,7 +67,7 @@ class OwnerRestrictedAdmin(admin.ModelAdmin):
 
 
 @admin.register(Species)
-class SpeciesAdmin(admin.ModelAdmin):
+class SpeciesAdmin(Select2AdminMixin, admin.ModelAdmin):
     list_display = ("popular_name", "scientific_name", "group")
     search_fields = ("popular_name", "scientific_name")
 
@@ -104,21 +117,8 @@ class HiveAdmin(OwnerRestrictedAdmin):
             kwargs["queryset"] = Apiary.objects.owned_by(request.user)
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
-    # TODO: colocar esse import em todo o django admin
-    class Media:
-        css = {
-            "all": (
-                "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css",
-            )
-        }
-        js = (
-            "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.full.min.js",
-            "apiary/js/hive_species_filter.js",
-        )
-
-
 @admin.register(Revision)
-class RevisionAdmin(admin.ModelAdmin):
+class RevisionAdmin(Select2AdminMixin, admin.ModelAdmin):
     list_display = (
         "hive",
         "review_date",
@@ -153,6 +153,6 @@ class RevisionAdmin(admin.ModelAdmin):
 
 
 @admin.register(RevisionAttachment)
-class RevisionAttachmentAdmin(admin.ModelAdmin):
+class RevisionAttachmentAdmin(Select2AdminMixin, admin.ModelAdmin):
     list_display = ("revision", "file")
     search_fields = ("revision__hive__identification_number",)

--- a/apiary/static/apiary/js/hive_species_filter.js
+++ b/apiary/static/apiary/js/hive_species_filter.js
@@ -3,22 +3,39 @@
     return;
   }
 
-  function initializeSpeciesFilter() {
-    // Select do filtro de espécies na lista de colmeias -> Funcionou
-    $('.list-filter-dropdown').find('select').select2();
+  function getSelects(context) {
+    return $(context)
+      .find('select')
+      .filter(function() {
+        var $select = $(this);
+        return (
+          !$select.is('.select2-hidden-accessible') &&
+          !$select.data('select2-initialized') &&
+          !$select.prop('disabled')
+        );
+      });
+  }
 
-    // Select do formulário de colmeia -> Funcionou
-    $('#id_species').select2();
+  function initializeSelect2(context) {
+    getSelects(context).each(function() {
+      var $select = $(this);
+      $select.select2({
+        width: 'style'
+      });
+      $select.data('select2-initialized', true);
+    });
+  }
 
-    // Select do formulário de revisões de colmeia-> Não funcionou
-    $('#id_hive').select2();
-
-    // TODO: Seria bom que o Select2 estive funcionando em todos o admin do Django.
+  function onReady() {
+    initializeSelect2(document);
+    $(document).on('formset:added', function(_event, $row) {
+      initializeSelect2($row);
+    });
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initializeSpeciesFilter);
+    document.addEventListener('DOMContentLoaded', onReady);
   } else {
-    initializeSpeciesFilter();
+    onReady();
   }
 })(typeof django !== 'undefined' ? django.jQuery : window.jQuery);


### PR DESCRIPTION
## Summary
- add a reusable mixin to include Select2 assets on every admin page
- initialize Select2 for all admin select fields, including dynamically added inlines

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dd4b9b3ba48332807feb62b2302ffc