### PR TITLE
feat: add configurable admin menu for non superusers

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,18 @@ As páginas criadas devem seguir o tema bootstrap do django-admin-interface, que
 - Intalação do tema bootstrap do django-admin-interface: python manage.py loaddata admin_interface_theme_bootstrap.json
 - Para customizar templates do admin, é necessário consultar a documentação/arquivos do template, por exemplo: https://github.com/fabiocaccamo/django-admin-interface/blob/main/admin_interface/templates/admin/base_site.html
 
+### Menu personalizado para o Django Admin
+
+O menu lateral exibido para usuários sem privilégio de superusuário pode ser configurado diretamente pelo próprio admin:
+
+1. Acesse **Configuração de menu** no admin (disponível apenas para superusuários) e crie um registro do tipo "Usuários sem privilégio de superusuário". Marque **Ativo** para habilitar a configuração e, opcionalmente, **Incluir itens não configurados** para que os modelos não listados sejam adicionados ao final do menu.
+2. Cadastre os **Itens de menu** relacionados, definindo a ordem manualmente. Itens do tipo **Modelo** esperam `app_label` e `modelo` conforme registrados no admin (ex.: `apiary` + `Hive`). Itens do tipo **Link** aceitam um `nome da URL` (para `reverse`) ou uma `URL absoluta`.
+3. Informe um rótulo customizado quando desejar alterar o texto exibido. Use o campo **Seção** para agrupar itens em um bloco com título próprio (ex.: "Operações").
+4. Para expor o dashboard de produção já existente, utilize um item do tipo Link com `nome da URL = "production-dashboard"`. Outros links customizados devem apontar para o nome de URL correspondente.
+5. Opcionalmente, defina **permissão necessária** (`app_label.codename`) para que o item apareça apenas quando o usuário possuir a permissão especificada.
+
+> **Nota:** esta feature introduz novos modelos (`MenuConfig` e `MenuItem`). Após atualizar o código, gere e aplique as migrations correspondentes manualmente (`python manage.py makemigrations && python manage.py migrate`).
+
 Clique [aqui](docs/padroes.md) para ver os padrões de desenvolvimento adotados no projeto.
 
 - **Boas práticas de migrations (Django)**: consulte o guia em [`docs/boas-praticas-migrations.md`](docs/boas-praticas-migrations.md).

--- a/apiary/admin.py
+++ b/apiary/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from core.admin_site import site as admin_site
+
 from .forms import ColmeiaForm, RevisaoForm
 from .models import (
     Apiary,
@@ -89,25 +91,25 @@ class OwnerRestrictedAdmin(BaseAdmin):
         return form
 
 
-@admin.register(Species)
+@admin_site.register(Species)
 class SpeciesAdmin(BaseAdmin):
     list_display = ("popular_name", "scientific_name", "group")
     search_fields = ("popular_name", "scientific_name")
 
 
-@admin.register(BoxModel)
+@admin_site.register(BoxModel)
 class BoxModelAdmin(BaseAdmin):
     list_display = ("name", "description")
     search_fields = ("name", "description")
 
 
-@admin.register(City)
+@admin_site.register(City)
 class CityAdmin(BaseAdmin):
     list_display = ("name",)
     search_fields = ("name",)
 
 
-@admin.register(Apiary)
+@admin_site.register(Apiary)
 class ApiaryAdmin(OwnerRestrictedAdmin):
     list_display = ("name", "city", "owner", "hive_count")
     search_fields = ("name", "city__name", "owner__username")
@@ -119,7 +121,7 @@ class RevisionAttachmentInline(BaseInline):
     extra = 0
 
 
-@admin.register(Hive)
+@admin_site.register(Hive)
 class ColmeiaAdmin(OwnerRestrictedAdmin):
     list_display = (
         "identification_number",
@@ -148,7 +150,7 @@ class ColmeiaAdmin(OwnerRestrictedAdmin):
             kwargs["queryset"] = Hive.objects.owned_by(request.user)
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
-@admin.register(Revision)
+@admin_site.register(Revision)
 class RevisaoAdmin(BaseAdmin):
     list_display = (
         "hive",
@@ -186,13 +188,13 @@ class RevisaoAdmin(BaseAdmin):
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
-@admin.register(RevisionAttachment)
+@admin_site.register(RevisionAttachment)
 class RevisionAttachmentAdmin(BaseAdmin):
     list_display = ("revision", "file")
     search_fields = ("revision__hive__identification_number",)
 
 
-@admin.register(CreatorNetworkEntry)
+@admin_site.register(CreatorNetworkEntry)
 class CreatorNetworkEntryAdmin(OwnerRestrictedAdmin):
     owner_field_name = "user"
     list_display = ("name", "city", "phone", "is_opt_in")

--- a/apiary/admin.py
+++ b/apiary/admin.py
@@ -91,25 +91,25 @@ class OwnerRestrictedAdmin(BaseAdmin):
         return form
 
 
-@admin_site.register(Species)
+@admin.register(Species, site=admin_site)
 class SpeciesAdmin(BaseAdmin):
     list_display = ("popular_name", "scientific_name", "group")
     search_fields = ("popular_name", "scientific_name")
 
 
-@admin_site.register(BoxModel)
+@admin.register(BoxModel, site=admin_site)
 class BoxModelAdmin(BaseAdmin):
     list_display = ("name", "description")
     search_fields = ("name", "description")
 
 
-@admin_site.register(City)
+@admin.register(City, site=admin_site)
 class CityAdmin(BaseAdmin):
     list_display = ("name",)
     search_fields = ("name",)
 
 
-@admin_site.register(Apiary)
+@admin.register(Apiary, site=admin_site)
 class ApiaryAdmin(OwnerRestrictedAdmin):
     list_display = ("name", "city", "owner", "hive_count")
     search_fields = ("name", "city__name", "owner__username")
@@ -121,7 +121,7 @@ class RevisionAttachmentInline(BaseInline):
     extra = 0
 
 
-@admin_site.register(Hive)
+@admin.register(Hive, site=admin_site)
 class ColmeiaAdmin(OwnerRestrictedAdmin):
     list_display = (
         "identification_number",
@@ -150,7 +150,7 @@ class ColmeiaAdmin(OwnerRestrictedAdmin):
             kwargs["queryset"] = Hive.objects.owned_by(request.user)
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
-@admin_site.register(Revision)
+@admin.register(Revision, site=admin_site)
 class RevisaoAdmin(BaseAdmin):
     list_display = (
         "hive",
@@ -188,13 +188,13 @@ class RevisaoAdmin(BaseAdmin):
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
-@admin_site.register(RevisionAttachment)
+@admin.register(RevisionAttachment, site=admin_site)
 class RevisionAttachmentAdmin(BaseAdmin):
     list_display = ("revision", "file")
     search_fields = ("revision__hive__identification_number",)
 
 
-@admin_site.register(CreatorNetworkEntry)
+@admin.register(CreatorNetworkEntry, site=admin_site)
 class CreatorNetworkEntryAdmin(OwnerRestrictedAdmin):
     owner_field_name = "user"
     list_display = ("name", "city", "phone", "is_opt_in")

--- a/core/admin.py
+++ b/core/admin.py
@@ -1,0 +1,93 @@
+"""Admin registrations for the configurable admin menu."""
+
+from __future__ import annotations
+
+from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
+
+from .admin_site import site
+from .models import MenuConfig, MenuItem
+
+
+class MenuItemInline(admin.TabularInline):
+    model = MenuItem
+    extra = 0
+    fields = (
+        "order",
+        "item_type",
+        "section",
+        "label",
+        "app_label",
+        "model_name",
+        "url_name",
+        "absolute_url",
+        "permission_codename",
+    )
+    ordering = ("order", "id")
+
+
+@admin.register(MenuConfig, site=site)
+class MenuConfigAdmin(admin.ModelAdmin):
+    list_display = ("name", "scope", "active", "include_unlisted", "updated_at")
+    list_filter = ("scope", "active")
+    search_fields = ("name",)
+    ordering = ("name",)
+    inlines = (MenuItemInline,)
+
+    def has_module_permission(self, request):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def has_view_permission(self, request, obj=None):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def has_add_permission(self, request):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def has_change_permission(self, request, obj=None):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def has_delete_permission(self, request, obj=None):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def save_model(self, request, obj, form, change):  # type: ignore[override]
+        obj.full_clean()
+        super().save_model(request, obj, form, change)
+
+
+@admin.register(MenuItem, site=site)
+class MenuItemAdmin(admin.ModelAdmin):
+    list_display = (
+        "display_label",
+        "config",
+        "item_type",
+        "order",
+    )
+    list_filter = ("item_type", "config__scope")
+    search_fields = (
+        "label",
+        "app_label",
+        "model_name",
+        "url_name",
+        "permission_codename",
+    )
+    ordering = ("config__name", "order", "id")
+    autocomplete_fields = ("config",)
+
+    def has_module_permission(self, request):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def has_view_permission(self, request, obj=None):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def has_add_permission(self, request):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def has_change_permission(self, request, obj=None):  # type: ignore[override]
+        return request.user.is_superuser
+
+    def has_delete_permission(self, request, obj=None):  # type: ignore[override]
+        return request.user.is_superuser
+
+    @admin.display(description=_("Rótulo"))
+    def display_label(self, obj: MenuItem) -> str:
+        return obj.label or obj.model_name or obj.url_name or str(obj.pk)

--- a/core/admin_config.py
+++ b/core/admin_config.py
@@ -1,0 +1,7 @@
+"""Custom AdminConfig to wire the controlled admin site as default."""
+
+from django.contrib.admin.apps import AdminConfig
+
+
+class ControlledAdminConfig(AdminConfig):
+    default_site = "core.admin_site.ControlledAdminSite"

--- a/core/admin_site.py
+++ b/core/admin_site.py
@@ -1,0 +1,264 @@
+"""Custom ``AdminSite`` with configurable menu for non-superusers."""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Iterable, cast
+
+from django.apps import apps
+from django.contrib import admin
+from django.contrib.admin import AdminSite
+from django.db import DatabaseError
+from django.urls import NoReverseMatch, reverse
+from django.utils.text import capfirst, slugify
+
+from .models import MenuConfig, MenuItem
+
+logger = logging.getLogger(__name__)
+
+
+class ControlledAdminSite(AdminSite):
+    """Admin site that exposes a curated menu for non-superusers."""
+
+    menu_scope = MenuConfig.MenuScope.NON_SUPERUSER
+
+    def get_app_list(self, request):  # type: ignore[override]
+        default_app_list = super().get_app_list(request)
+        if request.user.is_superuser:
+            return default_app_list
+
+        try:
+            config = (
+                MenuConfig.objects.filter(scope=self.menu_scope, active=True)
+                .prefetch_related("items")
+                .order_by("-updated_at")
+                .first()
+            )
+        except DatabaseError:
+            logger.debug("MenuConfig table unavailable, returning default admin menu.")
+            return default_app_list
+
+        if config is None:
+            return default_app_list
+
+        items = list(config.items.all())
+        if not items:
+            return default_app_list
+
+        builder = _MenuBuilder(self, request, default_app_list)
+        custom_menu = builder.build(items, include_unlisted=config.include_unlisted)
+        if custom_menu is None:
+            return default_app_list
+        return custom_menu
+
+
+@dataclass
+class _MenuGroup:
+    key: str
+    name: str
+    app_label: str
+    app_url: str | None
+    models: list[dict]
+
+
+class _MenuBuilder:
+    """Utility responsible for building the admin ``app_list`` structure."""
+
+    def __init__(self, admin_site: AdminSite, request, default_app_list: Iterable[dict]):
+        self.admin_site = admin_site
+        self.request = request
+        self.default_app_list = list(default_app_list)
+        self.groups: "OrderedDict[str, _MenuGroup]" = OrderedDict()
+        self.included_models: set[tuple[str, str]] = set()
+
+    # Public API ---------------------------------------------------------
+    def build(
+        self,
+        menu_items: Iterable[MenuItem],
+        *,
+        include_unlisted: bool,
+    ) -> list[dict] | None:
+        for item in menu_items:
+            try:
+                if item.item_type == MenuItem.ItemType.MODEL:
+                    self._add_model_item(item)
+                elif item.item_type == MenuItem.ItemType.URL:
+                    self._add_link_item(item)
+            except Exception:  # pragma: no cover - defensive guard
+                logger.exception("Erro ao montar item de menu %s", item.pk)
+
+        if not self.groups:
+            return None
+
+        if include_unlisted:
+            self._append_unlisted_entries()
+
+        return [self._serialize_group(group) for group in self.groups.values()]
+
+    # Internal helpers --------------------------------------------------
+    def _add_model_item(self, item: MenuItem) -> None:
+        if not item.app_label or not item.model_name:
+            return
+
+        try:
+            model = apps.get_model(item.app_label, item.model_name)
+        except LookupError:
+            logger.warning(
+                "Modelo %s.%s não encontrado para o menu", item.app_label, item.model_name
+            )
+            return
+
+        model_admin = self.admin_site._registry.get(model)
+        if model_admin is None:
+            logger.debug(
+                "Modelo %s não está registrado no admin, ignorando", model.__name__
+            )
+            return
+
+        if not model_admin.has_module_permission(self.request):
+            return
+
+        perms = model_admin.get_model_perms(self.request)
+        if not any(perms.values()):
+            return
+
+        info = (model_admin.opts.app_label, model_admin.opts.model_name)
+        label = item.label or capfirst(model_admin.opts.verbose_name_plural)
+        model_dict = {
+            "name": label,
+            "object_name": model_admin.opts.object_name,
+            "perms": perms,
+        }
+
+        if perms.get("view") or perms.get("change"):
+            try:
+                model_dict["admin_url"] = reverse(
+                    f"{self.admin_site.name}:{info[0]}_{info[1]}_changelist",
+                )
+            except NoReverseMatch:
+                logger.debug(
+                    "URL do changelist não encontrada para %s.%s", info[0], info[1]
+                )
+
+        if perms.get("add"):
+            try:
+                model_dict["add_url"] = reverse(
+                    f"{self.admin_site.name}:{info[0]}_{info[1]}_add",
+                )
+            except NoReverseMatch:
+                logger.debug(
+                    "URL de criação não encontrada para %s.%s", info[0], info[1]
+                )
+
+        model_dict["view_only"] = not perms.get("change")
+
+        group = self._resolve_group(item, model_admin)
+        group.models.append(model_dict)
+        self.included_models.add(info)
+
+    def _add_link_item(self, item: MenuItem) -> None:
+        url = None
+        if item.url_name:
+            try:
+                url = reverse(item.url_name)
+            except NoReverseMatch:
+                logger.info("URL nomeada %s não encontrada", item.url_name)
+        if url is None and item.absolute_url:
+            url = item.absolute_url
+        if url is None:
+            return
+
+        if item.permission_codename:
+            permission_codename = item.permission_codename.strip()
+            if permission_codename and not self.request.user.has_perm(permission_codename):
+                return
+
+        label = item.label or item.url_name or item.absolute_url
+        perms = {"add": False, "change": False, "delete": False, "view": True}
+        model_dict = {
+            "name": label,
+            "object_name": label,
+            "perms": perms,
+            "admin_url": url,
+            "view_only": True,
+        }
+
+        group = self._resolve_group(item, None)
+        group.models.append(model_dict)
+
+    def _resolve_group(self, item: MenuItem, model_admin) -> _MenuGroup:
+        if item.section:
+            display_name = item.section
+            group_key = f"section::{slugify(item.section) or 'section'}"
+            app_label = slugify(item.section) or "section"
+            app_url: str | None = None
+        elif model_admin is not None:
+            app_config = model_admin.opts.app_config
+            display_name = capfirst(app_config.verbose_name)
+            group_key = f"app::{app_config.label}" if app_config else f"app::{item.app_label}"
+            app_label = app_config.label if app_config else item.app_label
+            try:
+                app_url = reverse(
+                    f"{self.admin_site.name}:app_list",
+                    kwargs={"app_label": app_label},
+                )
+            except NoReverseMatch:
+                app_url = None
+        else:
+            display_name = "Links"
+            group_key = "section::links"
+            app_label = "links"
+            app_url = None
+
+        group = self.groups.get(group_key)
+        if group is None:
+            group = _MenuGroup(
+                key=group_key,
+                name=display_name,
+                app_label=app_label,
+                app_url=app_url,
+                models=[],
+            )
+            self.groups[group_key] = group
+        return group
+
+    def _append_unlisted_entries(self) -> None:
+        for app_entry in self.default_app_list:
+            app_label = app_entry.get("app_label")
+            if not app_label:
+                continue
+            group_key = f"app::{app_label}"
+            group = self.groups.get(group_key)
+            if group is None:
+                group = _MenuGroup(
+                    key=group_key,
+                    name=app_entry.get("name", capfirst(app_label)),
+                    app_label=app_label,
+                    app_url=app_entry.get("app_url"),
+                    models=[],
+                )
+                self.groups[group_key] = group
+
+            for model_dict in app_entry.get("models", []):
+                object_name = model_dict.get("object_name")
+                if not object_name:
+                    continue
+                identifier = (app_label, object_name.lower())
+                if identifier in self.included_models:
+                    continue
+                group.models.append(model_dict)
+
+    @staticmethod
+    def _serialize_group(group: _MenuGroup) -> dict:
+        app_url = group.app_url or "#"
+        return {
+            "name": group.name,
+            "app_label": group.app_label,
+            "app_url": app_url,
+            "models": group.models,
+        }
+
+
+site = cast(ControlledAdminSite, admin.site)

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"
+    verbose_name = "Configurações principais"
+
+    def ready(self) -> None:
+        # Importações tardias para evitar problemas de inicialização circular.
+        from . import admin  # noqa: F401  # registra os modelos auxiliares
+        from .admin_dashboard import apply_admin_customizations
+        from .admin_site import site
+
+        apply_admin_customizations(site)

--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,187 @@
+"""Core models used to configure the Django admin menu."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class MenuConfig(models.Model):
+    """Stores menu configuration metadata for the Django admin site."""
+
+    class MenuScope(models.TextChoices):
+        NON_SUPERUSER = "non_superuser", _("Usuários sem privilégio de superusuário")
+
+    name = models.CharField(
+        "nome",
+        max_length=100,
+        unique=True,
+        help_text=_("Identificador amigável exibido na lista do admin."),
+    )
+    scope = models.CharField(
+        "escopo",
+        max_length=32,
+        choices=MenuScope.choices,
+        default=MenuScope.NON_SUPERUSER,
+    )
+    active = models.BooleanField(
+        "ativo",
+        default=False,
+        help_text=_("Apenas uma configuração pode estar ativa por escopo."),
+    )
+    include_unlisted = models.BooleanField(
+        "incluir itens não configurados",
+        default=False,
+        help_text=_(
+            "Quando habilitado, itens padrão do admin não listados abaixo são "
+            "acrescentados ao final do menu."
+        ),
+    )
+    updated_at = models.DateTimeField(
+        "atualizado em",
+        auto_now=True,
+    )
+
+    class Meta:
+        verbose_name = _("Configuração de menu")
+        verbose_name_plural = _("Configurações de menu")
+        ordering = ("name",)
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.get_scope_display()})"
+
+    def clean(self) -> None:
+        super().clean()
+        if not self.active:
+            return
+        existing = (
+            MenuConfig.objects.filter(scope=self.scope, active=True)
+            .exclude(pk=self.pk)
+            .exists()
+        )
+        if existing:
+            raise ValidationError(
+                {
+                    "active": _(
+                        "Já existe uma configuração ativa para este escopo. "
+                        "Desative-a antes de ativar outra."
+                    )
+                }
+            )
+
+
+class MenuItem(models.Model):
+    """Defines an individual entry inside a ``MenuConfig``."""
+
+    class ItemType(models.TextChoices):
+        MODEL = "model", _("Modelo do Django")
+        URL = "url", _("Link personalizado")
+
+    config = models.ForeignKey(
+        MenuConfig,
+        on_delete=models.CASCADE,
+        related_name="items",
+        verbose_name=_("configuração"),
+    )
+    order = models.PositiveIntegerField(
+        "ordem",
+        default=0,
+        help_text=_("Itens são exibidos de acordo com este valor crescente."),
+    )
+    item_type = models.CharField(
+        "tipo",
+        max_length=20,
+        choices=ItemType.choices,
+    )
+    section = models.CharField(
+        "seção",
+        max_length=100,
+        blank=True,
+        help_text=_(
+            "Nome do agrupamento exibido na barra lateral. "
+            "Em branco usa o nome do aplicativo." 
+        ),
+    )
+    app_label = models.CharField(
+        "app_label",
+        max_length=100,
+        blank=True,
+        help_text=_("Formato: app_label do modelo (ex.: apiary)."),
+    )
+    model_name = models.CharField(
+        "modelo",
+        max_length=100,
+        blank=True,
+        help_text=_("Nome do modelo registrado no admin (ex.: Hive)."),
+    )
+    url_name = models.CharField(
+        "nome da URL",
+        max_length=200,
+        blank=True,
+        help_text=_("Nome completo da URL para ``reverse`` (ex.: dashboard:index)."),
+    )
+    absolute_url = models.URLField(
+        "URL absoluta",
+        blank=True,
+        help_text=_("Usada quando ``nome da URL`` não está disponível."),
+    )
+    label = models.CharField(
+        "rótulo",
+        max_length=120,
+        blank=True,
+        help_text=_("Texto exibido no menu. Em branco usa o nome padrão."),
+    )
+    permission_codename = models.CharField(
+        "permissão necessária",
+        max_length=150,
+        blank=True,
+        help_text=_(
+            "Opcional: informe no formato ``app_label.codename`` para limitar a "
+            "exibição do item." 
+        ),
+    )
+
+    class Meta:
+        verbose_name = _("Item de menu")
+        verbose_name_plural = _("Itens de menu")
+        ordering = ("order", "id")
+
+    def __str__(self) -> str:
+        base = self.label or self.model_name or self.url_name or "Item"
+        return f"{self.get_item_type_display()}: {base}"
+
+    def clean(self) -> None:
+        super().clean()
+        errors: dict[str, Iterable[str]] = {}
+        if self.item_type == self.ItemType.MODEL:
+            if not self.app_label:
+                errors.setdefault("app_label", []).append(_("Informe o app_label."))
+            if not self.model_name:
+                errors.setdefault("model_name", []).append(_("Informe o modelo."))
+        elif self.item_type == self.ItemType.URL:
+            if not self.url_name and not self.absolute_url:
+                errors.setdefault("url_name", []).append(
+                    _("Informe um nome de URL ou uma URL absoluta.")
+                )
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, **kwargs):
+        if self.app_label:
+            self.app_label = self.app_label.strip()
+        if self.model_name:
+            self.model_name = self.model_name.strip()
+        if self.url_name:
+            self.url_name = self.url_name.strip()
+        if self.label:
+            self.label = self.label.strip()
+        if self.section:
+            self.section = self.section.strip()
+        if self.permission_codename:
+            self.permission_codename = self.permission_codename.strip()
+        super().save(*args, **kwargs)
+
+

--- a/core/settings.py
+++ b/core/settings.py
@@ -60,12 +60,13 @@ else:
 
 # Application definition
 INSTALLED_APPS = [
+    "core.apps.CoreConfig",
     "admin_interface",
     "colorfield",
     "accounts",
     "apiary",
 
-    'django.contrib.admin',
+    'core.admin_config.ControlledAdminConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,9 +1,8 @@
-from django.contrib import admin
 from django.urls import include, path
 from django.conf import settings
 from django.conf.urls.static import static
 from django.views.generic import TemplateView
-from core import admin_dashboard  # noqa: F401  # Importa para aplicar o dashboard customizado
+from core.admin_site import site as admin_site
 from apiary.views import hive_production_detail, production_dashboard
 from core.views import PrivacyPolicyView, DeleteDataRedirectView
 
@@ -30,7 +29,7 @@ urlpatterns = [
         DeleteDataRedirectView.as_view(),
         name="privacy-delete-entry",
     ),
-    path('admin/', admin.site.urls),
+    path("admin/", admin_site.urls),
     path('accounts/', include('accounts.urls', namespace='accounts')),
 ]
 


### PR DESCRIPTION
## Escopo e impacto
- adiciona modelos e infraestrutura para controlar manualmente os itens exibidos no menu do Django Admin para usuários sem privilégio de superusuário, respeitando permissões e links personalizados.
- integra o novo `AdminSite` customizado com os apps existentes e documenta como configurar o menu no README.

## Sem migrations
- Foram criados os modelos `MenuConfig` e `MenuItem`. É necessário gerar e aplicar as migrations correspondentes manualmente (`python manage.py makemigrations && python manage.py migrate`).

## Checklist
- [x] Nenhum arquivo em `*/migrations/` foi criado/modificado/removido.
- [x] Alterações limitadas a código-fonte e/ou docs/tests.
- [x] Compatibilidade reversa razoável (quando envolve modelos/DB).
- [x] Docstrings, `help_text`, `verbose_name` e mensagens de erro revisadas.
- [x] TODOs claros onde o humano deverá gerar migrations de dados/índices.

## Testes
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_68df1e3eaa9c8332baada26fccb2bba1