### PR TITLE
feat: add admin image preview thumbnails

### DIFF
--- a/apiary/admin.py
+++ b/apiary/admin.py
@@ -18,12 +18,14 @@ class Select2AdminMixin:
         css = {
             "all": (
                 "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css",
+                "apiary/css/image-preview.css",
             )
         }
         js = (
             "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.full.min.js",
             "apiary/js/hive_species_filter.js",
-            "apiary/js/conditional-fields.js"
+            "apiary/js/conditional-fields.js",
+            "apiary/js/image-preview.js",
         )
 
 

--- a/apiary/forms.py
+++ b/apiary/forms.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from django import forms
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from .models import Hive, Revision
 
@@ -27,6 +28,22 @@ class ColmeiaForm(forms.ModelForm):
         self.fields["acquisition_date"].required = False
         self.fields["transfer_box_date"].required = False
         self.fields["origin_hive"].required = False
+
+        photo_field = self.fields.get("photo")
+        if photo_field is not None:
+            attrs = photo_field.widget.attrs
+            attrs["data-image-preview"] = "true"
+            attrs["data-preview-label"] = str(_("Prévia"))
+            attrs["data-preview-open-label"] = str(_("Abrir em nova aba"))
+
+            initial_url = ""
+            photo_instance = getattr(self.instance, "photo", None)
+            if photo_instance:
+                try:
+                    initial_url = photo_instance.url
+                except ValueError:
+                    initial_url = ""
+            attrs["data-initial-preview-url"] = initial_url
 
     def clean(self):
         cleaned_data = super().clean()

--- a/apiary/static/apiary/css/image-preview.css
+++ b/apiary/static/apiary/css/image-preview.css
@@ -1,0 +1,23 @@
+.thumb-150 {
+  max-width: 150px;
+  max-height: 150px;
+  object-fit: cover;
+  border-radius: 6px;
+  display: block;
+}
+
+.image-preview-wrapper {
+  margin-top: 0.5rem;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.image-preview-wrapper small {
+  font-weight: 600;
+  color: #444;
+}
+
+.image-preview-wrapper a {
+  font-size: 0.875rem;
+}

--- a/apiary/static/apiary/js/image-preview.js
+++ b/apiary/static/apiary/js/image-preview.js
@@ -1,0 +1,183 @@
+/* global window, document */
+(function () {
+  "use strict";
+
+  const SELECTOR = 'input[type="file"][data-image-preview="true"]';
+
+  function toArray(list) {
+    if (!list) {
+      return [];
+    }
+    return Array.prototype.slice.call(list);
+  }
+
+  function buildPreviewElements(input) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "image-preview-wrapper";
+
+    const header = document.createElement("div");
+    header.className = "image-preview-header";
+
+    const label = document.createElement("small");
+    label.textContent = input.getAttribute("data-preview-label") || "Prévia";
+    header.appendChild(label);
+
+    const link = document.createElement("a");
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = input.getAttribute("data-preview-open-label") || "Abrir em nova aba";
+    link.className = "image-preview-link";
+    link.hidden = true;
+    header.appendChild(link);
+
+    const image = document.createElement("img");
+    image.className = "thumb-150";
+    image.alt = label.textContent || "Prévia";
+    image.hidden = true;
+
+    wrapper.appendChild(header);
+    wrapper.appendChild(image);
+
+    return { wrapper, label, image, link };
+  }
+
+  function findWidgetContainer(input) {
+    return (
+      input.closest(".clearable-file-input") ||
+      input.closest(".form-row") ||
+      input.parentElement ||
+      input
+    );
+  }
+
+  function updatePreviewVisibility(elements, { imageUrl, linkUrl }) {
+    const { wrapper, image, link } = elements;
+
+    if (imageUrl) {
+      image.src = imageUrl;
+      image.hidden = false;
+      wrapper.hidden = false;
+    } else {
+      image.removeAttribute("src");
+      image.hidden = true;
+      wrapper.hidden = true;
+    }
+
+    if (linkUrl) {
+      link.href = linkUrl;
+      link.hidden = false;
+    } else {
+      link.removeAttribute("href");
+      link.hidden = true;
+    }
+  }
+
+  function handleChange(input, elements, state) {
+    const clearCheckbox = state.clearCheckbox;
+    const initialUrl = state.initialUrl;
+
+    if (!input.files || input.files.length === 0) {
+      if (clearCheckbox && clearCheckbox.checked) {
+        updatePreviewVisibility(elements, { imageUrl: "", linkUrl: "" });
+        return;
+      }
+      if (initialUrl) {
+        updatePreviewVisibility(elements, { imageUrl: initialUrl, linkUrl: initialUrl });
+      } else {
+        updatePreviewVisibility(elements, { imageUrl: "", linkUrl: "" });
+      }
+      return;
+    }
+
+    const file = input.files[0];
+    if (!window.FileReader) {
+      updatePreviewVisibility(elements, { imageUrl: "", linkUrl: "" });
+      return;
+    }
+
+    const reader = new window.FileReader();
+    reader.addEventListener("load", function (event) {
+      updatePreviewVisibility(elements, { imageUrl: event.target.result, linkUrl: "" });
+      if (clearCheckbox) {
+        clearCheckbox.checked = false;
+      }
+    });
+    reader.addEventListener("error", function () {
+      updatePreviewVisibility(elements, { imageUrl: "", linkUrl: "" });
+    });
+    reader.readAsDataURL(file);
+  }
+
+  function bindClearCheckbox(clearCheckbox, input, elements, state) {
+    if (!clearCheckbox) {
+      return;
+    }
+
+    clearCheckbox.addEventListener("change", function () {
+      if (clearCheckbox.checked) {
+        updatePreviewVisibility(elements, { imageUrl: "", linkUrl: "" });
+        if (input.value) {
+          input.value = "";
+        }
+      } else if (!input.files || input.files.length === 0) {
+        if (state.initialUrl) {
+          updatePreviewVisibility(elements, { imageUrl: state.initialUrl, linkUrl: state.initialUrl });
+        } else {
+          updatePreviewVisibility(elements, { imageUrl: "", linkUrl: "" });
+        }
+      }
+    });
+  }
+
+  function initialiseInput(input) {
+    if (!input || input.dataset.imagePreviewInitialised === "true") {
+      return;
+    }
+    input.dataset.imagePreviewInitialised = "true";
+
+    const initialUrl = input.getAttribute("data-initial-preview-url") || "";
+    const elements = buildPreviewElements(input);
+    const widgetContainer = findWidgetContainer(input);
+
+    if (widgetContainer && widgetContainer !== input) {
+      widgetContainer.insertAdjacentElement("afterend", elements.wrapper);
+    } else if (input.parentElement) {
+      input.parentElement.insertBefore(elements.wrapper, input.nextSibling);
+    } else {
+      input.insertAdjacentElement("afterend", elements.wrapper);
+    }
+
+    const state = {
+      initialUrl,
+      clearCheckbox: null,
+    };
+
+    const clearableContainer = input.closest(".clearable-file-input");
+    if (clearableContainer) {
+      state.clearCheckbox = clearableContainer.querySelector('input[type="checkbox"]');
+    }
+
+    bindClearCheckbox(state.clearCheckbox, input, elements, state);
+    handleChange(input, elements, state);
+
+    input.addEventListener("change", function () {
+      handleChange(input, elements, state);
+    });
+  }
+
+  function initialise(root) {
+    const inputs = toArray((root || document).querySelectorAll(SELECTOR));
+    inputs.forEach(initialiseInput);
+  }
+
+  window.addEventListener("DOMContentLoaded", function () {
+    initialise(document);
+  });
+
+  document.addEventListener("formset:added", function (event) {
+    if (!event || !event.target) {
+      return;
+    }
+    initialise(event.target);
+  });
+})();


### PR DESCRIPTION
## Summary
- add data attributes to the Colmeia form so the photo field exposes preview metadata to the frontend script
- load reusable image-preview assets in the admin alongside existing conditional fields handling
- implement image preview CSS/JS to render thumbnails, update on change, and hide when cleared

## Testing
- python -m compileall apiary/forms.py

------
https://chatgpt.com/codex/tasks/task_e_68df31bae6c48332ab9e28d4403424e8