### PR TITLE
Atualiza cartões de revisão na história da colmeia

### DIFF
--- a/templates/admin/hive_history.html
+++ b/templates/admin/hive_history.html
@@ -843,7 +843,7 @@
                                                                         <img src="{{ attachment.url }}" alt="{{ attachment.alt }}" loading="lazy">
                                                                         <figcaption>
                                                                             <a href="{{ attachment.url }}" target="_blank" rel="noopener">
-                                                                                {{ attachment.name|default:attachment.caption }}
+                                                                                {{ attachment.name|default:attachment.caption|truncatechars:20 }}
                                                                             </a>
                                                                         </figcaption>
                                                                     </figure>

--- a/templates/admin/hive_history.html
+++ b/templates/admin/hive_history.html
@@ -384,6 +384,205 @@
         margin-bottom: 0.65rem;
     }
 
+    .revision-card {
+        display: flex;
+        flex-direction: column;
+        gap: 1.1rem;
+    }
+
+    .revision-card__common-grid {
+        margin: 0;
+        padding: 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem;
+    }
+
+    .revision-card__common-item {
+        background: #ffffff;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 0.8rem;
+        padding: 0.75rem 0.9rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        min-height: 86px;
+    }
+
+    .revision-card__common-item dt {
+        margin: 0;
+        font-size: 0.78rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: var(--hh-muted);
+    }
+
+    .revision-card__common-item dd {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+        color: #0f172a;
+    }
+
+    .revision-card__details {
+        border-top: 1px solid rgba(148, 163, 184, 0.28);
+        padding-top: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.1rem;
+    }
+
+    .revision-card__toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        list-style: none;
+        outline: none;
+    }
+
+    .revision-card__toggle::-webkit-details-marker {
+        display: none;
+    }
+
+    .revision-card__toggle::after {
+        content: "\25BC";
+        font-size: 0.75rem;
+        transition: transform 0.2s ease;
+    }
+
+    .revision-card__toggle-label--less {
+        display: none;
+    }
+
+    .revision-card__details[open] > .revision-card__toggle::after {
+        transform: rotate(180deg);
+    }
+
+    .revision-card__details[open] > .revision-card__toggle .revision-card__toggle-label--more {
+        display: none;
+    }
+
+    .revision-card__details[open] > .revision-card__toggle .revision-card__toggle-label--less {
+        display: inline;
+    }
+
+    .revision-card__section {
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        border-radius: 0.85rem;
+        padding: 0.9rem 1rem;
+        background: #ffffff;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .revision-card__section h4 {
+        margin: 0;
+        font-size: 0.95rem;
+        color: #0f172a;
+    }
+
+    .revision-card__section dl {
+        margin: 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.6rem;
+    }
+
+    .revision-card__section-item {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+    }
+
+    .revision-card__section-item dt {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--hh-muted);
+    }
+
+    .revision-card__section-item dd {
+        margin: 0;
+        font-weight: 600;
+        color: #0f172a;
+    }
+
+    .revision-card__notes {
+        display: flex;
+        flex-direction: column;
+        gap: 0.9rem;
+    }
+
+    .revision-card__note h4 {
+        margin: 0 0 0.35rem;
+        font-size: 0.95rem;
+        color: #0f172a;
+    }
+
+    .revision-card__note p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: #0f172a;
+        line-height: 1.6;
+        white-space: pre-wrap;
+    }
+
+    .revision-card__attachments h4 {
+        margin: 0 0 0.45rem;
+        font-size: 0.95rem;
+        color: #0f172a;
+    }
+
+    .revision-card__attachment-list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.85rem;
+    }
+
+    .revision-card__attachment figure {
+        margin: 0;
+        width: 150px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+    }
+
+    .revision-card__attachment img {
+        width: 150px;
+        height: auto;
+        border-radius: 0.65rem;
+        object-fit: cover;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+    }
+
+    .revision-card__attachment figcaption {
+        font-size: 0.75rem;
+        color: var(--hh-muted);
+        text-align: center;
+    }
+
+    .revision-card__attachment a {
+        color: var(--hh-accent);
+        text-decoration: none;
+        font-weight: 600;
+    }
+
+    .revision-card__attachment a:hover,
+    .revision-card__attachment a:focus-visible {
+        text-decoration: underline;
+    }
+
+    .revision-card__empty {
+        margin: 0;
+        font-size: 0.9rem;
+        color: var(--hh-muted);
+    }
+
     .timeline-item__media {
         display: flex;
         flex-wrap: wrap;
@@ -591,51 +790,106 @@
                                         </a>
                                     {% endif %}
                                 </div>
-                                {% if item.preview %}
-                                    <p class="timeline-item__preview">{{ item.preview|linebreaksbr }}</p>
-                                {% elif not item.has_more and not item.sections %}
-                                    <p class="timeline-item__no-notes">{% trans "Sem observações adicionais." %}</p>
-                                {% endif %}
-                                {% if item.sections %}
-                                    <div class="timeline-item__sections">
-                                        {% for section in item.sections %}
-                                            <div class="timeline-section">
-                                                <h4>{{ section.title }}</h4>
-                                                <ul>
-                                                    {% for metric in section.items %}
-                                                        <li><span>{{ metric.label }}</span><strong>{{ metric.value|floatformat:2 }}</strong></li>
-                                                    {% endfor %}
-                                                </ul>
-                                            </div>
-                                        {% endfor %}
-                                    </div>
-                                {% endif %}
-                                {% if item.has_more %}
-                                    <details class="timeline-item__details">
-                                        <summary>{% trans "Ver mais" %}</summary>
-                                        {% if item.full_text %}
-                                            <div class="timeline-item__full-text">{{ item.full_text|linebreaksbr }}</div>
-                                        {% endif %}
-                                        {% if item.attachments %}
-                                            <div class="timeline-item__media">
-                                                {% for attachment in item.attachments %}
-                                                    <figure>
-                                                        <img src="{{ attachment.url }}" alt="{{ attachment.alt }}" loading="lazy">
-                                                        <figcaption>{{ attachment.caption }}</figcaption>
-                                                    </figure>
+                                {% if item.type == "revision" %}
+                                    <div class="revision-card">
+                                        <div class="revision-card__common">
+                                            <dl class="revision-card__common-grid">
+                                                {% for field in item.common_fields %}
+                                                    <div class="revision-card__common-item">
+                                                        <dt>{{ field.label }}</dt>
+                                                        <dd>{{ field.value }}</dd>
+                                                    </div>
                                                 {% endfor %}
-                                            </div>
+                                            </dl>
+                                        </div>
+                                        {% if item.has_more %}
+                                            <details class="timeline-item__details revision-card__details">
+                                                <summary class="revision-card__toggle">
+                                                    <span class="revision-card__toggle-label revision-card__toggle-label--more">{% trans "Ver mais" %}</span>
+                                                    <span class="revision-card__toggle-label revision-card__toggle-label--less">{% trans "Ver menos" %}</span>
+                                                </summary>
+                                                {% if item.sections %}
+                                                    {% for section in item.sections %}
+                                                        <div class="revision-card__section">
+                                                            <h4>{{ section.title }}</h4>
+                                                            <dl>
+                                                                {% for metric in section.items %}
+                                                                    <div class="revision-card__section-item">
+                                                                        <dt>{{ metric.label }}</dt>
+                                                                        <dd>{{ metric.value }}</dd>
+                                                                    </div>
+                                                                {% endfor %}
+                                                            </dl>
+                                                        </div>
+                                                    {% endfor %}
+                                                {% endif %}
+                                                {% if item.notes_sections %}
+                                                    <div class="revision-card__notes">
+                                                        {% for note in item.notes_sections %}
+                                                            <div class="revision-card__note">
+                                                                <h4>{{ note.label }}</h4>
+                                                                <p>{{ note.content|linebreaksbr }}</p>
+                                                            </div>
+                                                        {% endfor %}
+                                                    </div>
+                                                {% endif %}
+                                                <div class="revision-card__attachments">
+                                                    <h4>{% trans "Anexos" %}</h4>
+                                                    {% if item.attachments %}
+                                                        <ul class="revision-card__attachment-list">
+                                                            {% for attachment in item.attachments %}
+                                                                <li class="revision-card__attachment">
+                                                                    <figure>
+                                                                        <img src="{{ attachment.url }}" alt="{{ attachment.alt }}" loading="lazy">
+                                                                        <figcaption>
+                                                                            <a href="{{ attachment.url }}" target="_blank" rel="noopener">
+                                                                                {{ attachment.name|default:attachment.caption }}
+                                                                            </a>
+                                                                        </figcaption>
+                                                                    </figure>
+                                                                </li>
+                                                            {% endfor %}
+                                                        </ul>
+                                                    {% else %}
+                                                        <p class="revision-card__empty">{% trans "Sem anexos" %}</p>
+                                                    {% endif %}
+                                                </div>
+                                            </details>
                                         {% endif %}
-                                    </details>
-                                {% elif item.attachments %}
-                                    <div class="timeline-item__media">
-                                        {% for attachment in item.attachments %}
-                                            <figure>
-                                                <img src="{{ attachment.url }}" alt="{{ attachment.alt }}" loading="lazy">
-                                                <figcaption>{{ attachment.caption }}</figcaption>
-                                            </figure>
-                                        {% endfor %}
                                     </div>
+                                {% else %}
+                                    {% if item.preview %}
+                                        <p class="timeline-item__preview">{{ item.preview|linebreaksbr }}</p>
+                                    {% elif not item.has_more %}
+                                        <p class="timeline-item__no-notes">{% trans "Sem observações adicionais." %}</p>
+                                    {% endif %}
+                                    {% if item.has_more %}
+                                        <details class="timeline-item__details">
+                                            <summary>{% trans "Ver mais" %}</summary>
+                                            {% if item.full_text %}
+                                                <div class="timeline-item__full-text">{{ item.full_text|linebreaksbr }}</div>
+                                            {% endif %}
+                                            {% if item.attachments %}
+                                                <div class="timeline-item__media">
+                                                    {% for attachment in item.attachments %}
+                                                        <figure>
+                                                            <img src="{{ attachment.url }}" alt="{{ attachment.alt }}" loading="lazy">
+                                                            <figcaption>{{ attachment.caption }}</figcaption>
+                                                        </figure>
+                                                    {% endfor %}
+                                                </div>
+                                            {% endif %}
+                                        </details>
+                                    {% elif item.attachments %}
+                                        <div class="timeline-item__media">
+                                            {% for attachment in item.attachments %}
+                                                <figure>
+                                                    <img src="{{ attachment.url }}" alt="{{ attachment.alt }}" loading="lazy">
+                                                    <figcaption>{{ attachment.caption }}</figcaption>
+                                                </figure>
+                                            {% endfor %}
+                                        </div>
+                                    {% endif %}
                                 {% endif %}
                             </div>
                         </li>


### PR DESCRIPTION
## Sumário
- ajusta a montagem dos dados de revisões para expor campos comuns, seções específicas e notas textuais
- refina o cartão de revisão na história da colmeia para mostrar os campos padrão e mover detalhes e anexos para o bloco "Ver mais"

## Testes
- `python manage.py test apiary.tests.test_hive_history` *(falhou: migrations antigas ainda referenciam o campo removido `management_performed`)*

------
https://chatgpt.com/codex/tasks/task_e_68e07f8c85a4833294219214dfa65e5f